### PR TITLE
Fix user input crash

### DIFF
--- a/chessengine/bitboard.py
+++ b/chessengine/bitboard.py
@@ -668,7 +668,7 @@ class Board:
                         return
                     if move.lower() == "u":
                         input_accepted = True
-                        move_undone = True # this helps us break out of the input loop
+                        move_undone = True  # this helps us break out of the input loop
                         try:
                             self.undo_move()
                             self.undo_move()

--- a/chessengine/bitboard.py
+++ b/chessengine/bitboard.py
@@ -674,7 +674,7 @@ class Board:
                             self.undo_move()
                         except RuntimeError:
                             print("No moves have been made yet to undo!\n")
-                        continue
+                        break
 
                     # input was normal move:
                     try:

--- a/chessengine/bitboard.py
+++ b/chessengine/bitboard.py
@@ -654,21 +654,41 @@ class Board:
                     )
                 print(self)
             else:
-                move = input(
-                    "Enter the move you want to make in standard algebraic notation - "
-                ).strip()
-                if move.lower() == "q":
-                    print("Thanks for playing!")
-                    return
-                if move.lower() == "u":
+                # ask for user input until accepted:
+                input_accepted = False
+                move_undone = False
+                num_wrong_tries = 0
+                while input_accepted is False:
+                    move = input(
+                        "Enter the move you want to make in standard algebraic notation - "
+                    ).strip()
+                    if move.lower() == "q":
+                        input_accepted = True
+                        print("Thanks for playing!")
+                        return
+                    if move.lower() == "u":
+                        input_accepted = True
+                        move_undone = True # this helps us break out of the input loop
+                        try:
+                            self.undo_move()
+                            self.undo_move()
+                        except RuntimeError:
+                            print("No moves have been made yet to undo!\n")
+                        continue
+
+                    # input was normal move:
                     try:
-                        self.undo_move()
-                        self.undo_move()
-                    except RuntimeError:
-                        print("No moves have been made yet to undo!\n")
+                        self.move_san(move=move, side=side_to_move)
+                        input_accepted = True
+                    except ValueError as e:
+                        num_wrong_tries += 1
+                        print(e)
+                # (end of input loop)
+                clear_lines(2 * num_wrong_tries)
+                if move_undone is True:
+                    # return to outer loop, so both sides need to make a new move:
                     continue
 
-                self.move_san(move=move, side=side_to_move)
                 if in_game_tree:
                     try:
                         current_node = current_node.get_child(move)


### PR DESCRIPTION
I've wrapped the part that asks for user input and tries to execute it in a loop.  
If parsing or executing the move throws a ValueError, this is catched, error message printed on stdout, and the user will be asked for input again.  
Tried to change as little as possible, to not provoke any merge conflicts. ;)