### PR TITLE
Allow different input formats

### DIFF
--- a/chessengine/bitboard.py
+++ b/chessengine/bitboard.py
@@ -34,7 +34,7 @@ from chessengine.lookup_tables import (
     pos_to_coords,
     san_piece_map,
 )
-from chessengine.utils import get_bit_positions, get_file, clear_lines
+from chessengine.utils import get_bit_positions, get_file, clear_lines, to_san
 from chessengine.pgn.parser import PGNParser, SAN_MOVE_REGEX
 
 
@@ -680,7 +680,7 @@ class Board:
 
                     # input was normal move
                     try:
-                        self.move_san(move=move, side=side_to_move)
+                        self.move_san(move=to_san(move), side=side_to_move)
                         input_accepted = True
                     except ValueError as e:
                         print(e)
@@ -736,7 +736,7 @@ class Board:
                     break
 
                 try:
-                    self.move_san(move=move, side=side_to_move)
+                    self.move_san(move=to_san(move), side=side_to_move)
                     input_accepted = True
                     last_move = f"{side_to_move.capitalize()} moved {move}"
                 except ValueError as e:

--- a/chessengine/utils.py
+++ b/chessengine/utils.py
@@ -4,6 +4,7 @@ Utility functions for common bitboard operations.
 
 
 from math import log2
+from re import sub
 
 
 piece_characters = {
@@ -78,7 +79,13 @@ def clear_lines(n: int) -> None:
 
 def to_san(move: str) -> str:
     """
+    Attempts to translate a move in any input format into
+    standard algebraic notation (SAN).
+    This is intended as a layer between getting the user input
+    and passing it on to the #move_san method in #bitboard.py .
     """
-    # do some translation stuff
+    # Strip off leading move numbers (like 10... h5 -> h5):
+    move = sub(r'^[1-9][0-9]*\.+ ?', '', move)
+
     return move
 

--- a/chessengine/utils.py
+++ b/chessengine/utils.py
@@ -75,3 +75,10 @@ def clear_lines(n: int) -> None:
     LINE_CLEAR = "\x1b[2K"
     for i in range(n):
         print(LINE_UP, end=LINE_CLEAR)
+
+def to_san(move: str) -> str:
+    """
+    """
+    # do some translation stuff
+    return move
+

--- a/chessengine/utils.py
+++ b/chessengine/utils.py
@@ -77,6 +77,7 @@ def clear_lines(n: int) -> None:
     for i in range(n):
         print(LINE_UP, end=LINE_CLEAR)
 
+
 def to_san(move: str) -> str:
     """
     Attempts to translate a move in any input format into
@@ -89,18 +90,19 @@ def to_san(move: str) -> str:
     for a take back), you must parse the move for those
     instructions before applying this function.
     """
+
     def capitalize(match):
         return match[0].upper()
+
     # Strip off leading move numbers (like 10... h5 -> h5):
-    move = re.sub(r'^[1-9][0-9]*\.+ ?', '', move)
+    move = re.sub(r"^[1-9][0-9]*\.+ ?", "", move)
     # Strip off starting square and dashes in straight
     # (non-capturing) pawn moves (like e2-e4 -> e4):
-    move = re.sub(r'^([a-h])[2-7] ?- ?\1([1-8])', r'\1\2', move)
+    move = re.sub(r"^([a-h])[2-7] ?- ?\1([1-8])", r"\1\2", move)
     # Allow lowercase piece names (like nf3 -> Nf3):
     # For pieces that cannot be confused with file names:
-    move = re.sub(r'^[rnqk]', capitalize, move)
+    move = re.sub(r"^[rnqk]", capitalize, move)
     # For bishops, in cases where it cannot be confused with
     # the b pawn (like bg5 -> Bg5):
-    move = re.sub(r'^b([d-h][1-8])', r'B\1', move)
+    move = re.sub(r"^b([d-h][1-8])", r"B\1", move)
     return move
-

--- a/chessengine/utils.py
+++ b/chessengine/utils.py
@@ -3,8 +3,8 @@ Utility functions for common bitboard operations.
 """
 
 
+import re
 from math import log2
-from re import sub
 
 
 piece_characters = {
@@ -82,10 +82,25 @@ def to_san(move: str) -> str:
     Attempts to translate a move in any input format into
     standard algebraic notation (SAN).
     This is intended as a layer between getting the user input
-    and passing it on to the #move_san method in #bitboard.py .
+    and passing it on to the #move_san method in #bitboard.py ,
+    in order to not annoy users who are unfamiliar with SAN.
+    NOTE: If the user input can also contain other, non-move-
+    related instructions (such as ending the game, or asking
+    for a take back), you must parse the move for those
+    instructions before applying this function.
     """
+    def capitalize(match):
+        return match[0].upper()
     # Strip off leading move numbers (like 10... h5 -> h5):
-    move = sub(r'^[1-9][0-9]*\.+ ?', '', move)
-
+    move = re.sub(r'^[1-9][0-9]*\.+ ?', '', move)
+    # Strip off starting square and dashes in straight
+    # (non-capturing) pawn moves (like e2-e4 -> e4):
+    move = re.sub(r'^([a-h])[2-7] ?- ?\1([1-8])', r'\1\2', move)
+    # Allow lowercase piece names (like nf3 -> Nf3):
+    # For pieces that cannot be confused with file names:
+    move = re.sub(r'^[rnqk]', capitalize, move)
+    # For bishops, in cases where it cannot be confused with
+    # the b pawn (like bg5 -> Bg5):
+    move = re.sub(r'^b([d-h][1-8])', r'B\1', move)
     return move
 


### PR DESCRIPTION
This should make the parsing of the move the user inputs a bit more liberal. (See the discussion in #9 )

The following replacements are done:  
* Leading move numbers stripped (as in `1. e4`)
* pawn move notation with starting square and dash is allowed (e. g. `d2-d4`)
* lowercase piece names are allowed in cases where it's clear what was meant (e. g. `bg5` is accepted as `Bg5`, but `bc4` is not accepted as it's not clear whether this should be `Bc4` or `bxc4`)